### PR TITLE
Add debug-bundle to the debug-pack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "description": "A debug pack for Symfony projects",
     "require": {
         "php": "^7.0",
+        "symfony/debug-bundle": "^3.3|^4.0",
         "symfony/monolog-bundle": "^3.0",
         "easycorp/easy-log-handler": "^1.0.2",
         "symfony/profiler-pack": "^1.0",


### PR DESCRIPTION
I just installed the debug-pack and was wondering, why my `dump(...)` wasn't showing in my webprofiler toolbar.

I would intuitively assume, that the integration code for `dump()` comes with the installation that adds `dump()`.

Maybe one should add this to the `profiler-pack` as well?