### PR TITLE
Upgrade easy-log-handler to 1.0.7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.0",
         "symfony/debug-bundle": "^3.3|^4.0",
         "symfony/monolog-bundle": "^3.0",
-        "easycorp/easy-log-handler": "^1.0.2",
+        "easycorp/easy-log-handler": "^1.0.7",
         "symfony/profiler-pack": "^1.0",
         "symfony/var-dumper": "^3.3|^4.0"
     }


### PR DESCRIPTION
Fresh easy-log-handler version: https://github.com/EasyCorp/easy-log-handler/releases
Fixed errors:
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to EasyCorp\EasyLog\EasyLogFormatter::formatThrowable() must be an instance of EasyCorp\EasyLog\Throwable, instance of XXXX
```