### PR TITLE
Don't restrict symfony/symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "description": "A debug pack for Symfony projects",
     "require": {
         "php": "^7.0",
-        "symfony/debug-bundle": "^3.3|^4.0",
+        "symfony/debug-bundle": "*",
         "symfony/monolog-bundle": "^3.0",
         "easycorp/easy-log-handler": "^1.0.7",
-        "symfony/profiler-pack": "^1.0",
-        "symfony/var-dumper": "^3.3|^4.0"
+        "symfony/profiler-pack": "*",
+        "symfony/var-dumper": "*"
     }
 }


### PR DESCRIPTION
will allow "unpack" to replace the wildcard by what's in extra.symfony.require also (PR to come)