### PR TITLE
Duplicate require-dev into require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
     "require": {
         "symfony/debug-bundle": "*",
         "symfony/monolog-bundle": "^3.0",
-        "symfony/profiler-pack": "*",
-        "symfony/var-dumper": "*"
+        "symfony/profiler-pack": "*"
+    },
+    "require-dev": {
+        "symfony/debug-bundle": "*",
+        "symfony/profiler-pack": "*"
     }
 }


### PR DESCRIPTION
Together with https://github.com/symfony/flex/pull/782, this will install `symfony/debug-bundle` and `symfony/profiler-pack` as dev-deps.

`symfony/var-dumper` is not needed since it's a dep of `error-handler`.

And `symfony/monolog-bundle` should stay in `require` IMHO.